### PR TITLE
Specify non default sqs region

### DIFF
--- a/plugins/aws_sqs_queue_length_
+++ b/plugins/aws_sqs_queue_length_
@@ -32,6 +32,7 @@ class AWSSQSQueueLengthPlugin(MuninPlugin):
         self.api_key = os.environ['AWS_KEY']
         self.secret_key = os.environ['AWS_SECRET']
         self.queues = (sys.argv[0].rsplit('_', 1)[-1] or os.environ['SQS_QUEUES']).split(',')
+        self.region = os.environ.get('AWS_REGION', "us-east-1")
 
     def execute(self):
         conn = SQSConnection(self.api_key, self.secret_key)

--- a/plugins/aws_sqs_queue_length_
+++ b/plugins/aws_sqs_queue_length_
@@ -35,7 +35,7 @@ class AWSSQSQueueLengthPlugin(MuninPlugin):
         self.region = os.environ.get('AWS_REGION', "us-east-1")
 
     def execute(self):
-        conn = SQSConnection(self.api_key, self.secret_key)
+        conn = boto.sqs.connect_to_region(self.region, aws_access_key_id=self.api_key, aws_secret_access_key=self.secret_key)
         return dict(
             (qname, conn.get_queue(qname).count())
             for qname in self.queues

--- a/plugins/aws_sqs_queue_length_
+++ b/plugins/aws_sqs_queue_length_
@@ -16,7 +16,7 @@ class AWSSQSQueueLengthPlugin(MuninPlugin):
 
     @property
     def title(self):
-        return "Length of AWS SQS queues '%s'" % ",".join(self.queues)
+        return "Length of AWS SQS queues in '%s'" % self.region
 
     @property
     def fields(self):


### PR DESCRIPTION
Fixes #11
- Allows the munin plugin config var "env.AWS_REGION = <aws_region>" to override the default boto region of 'us-east-1'
- Change title of graph to display region name instead of queue name. This fixes the issue when checking multiple queues would cause the title to overflow.
