### PR TITLE
Adding ability to graph multiple SQS queues via symlink

### DIFF
--- a/plugins/aws_sqs_queue_length_
+++ b/plugins/aws_sqs_queue_length_
@@ -31,7 +31,7 @@ class AWSSQSQueueLengthPlugin(MuninPlugin):
     def __init__(self):
         self.api_key = os.environ['AWS_KEY']
         self.secret_key = os.environ['AWS_SECRET']
-        self.queues = (sys.argv[0].rsplit('_', 1)[-1] or os.environ['SQS_QUEUES']).split(',')
+        self.queues = (sys.argv[0].rsplit('_', 1)[-1].split(':') or os.environ['SQS_QUEUES'].split(','))
 
     def execute(self):
         conn = SQSConnection(self.api_key, self.secret_key)


### PR DESCRIPTION
- Adding ability to use ":" separator for symlinks. This allows one graph to contain multiple message queues without setting an environment variable. Ex. "ln -s aws_sqs_queue_length_testqueue1:testqueue2:testqueue3 => /usr/share/munin/plugins/aws_sqs_queue_length_"
  - I added this ability because I was unable to specify multiple queues via a symlink using "," as a separator. Munin gave me an error of `# ERROR: Invalid plugin name 'aws_sqs_queue_length_testqueue1,testqueue2.` 
- Retaining ability to use the "," separator for queues to graph specified via "os.environ['SQS_QUEUES']"
