### PR TITLE
MOD: fix mongodb_replset_lag bug, oldest_secondary_optime is a int value

### DIFF
--- a/plugins/mongodb_replset_lag
+++ b/plugins/mongodb_replset_lag
@@ -30,7 +30,7 @@ class MongoReplicaSetLag(MuninMongoDBPlugin):
             if member_state == PRIMARY_STATE:
                 primary_optime = optime.time
             elif member_state == SECONDARY_STATE:
-                if not oldest_secondary_optime or optime.time < oldest_secondary_optime.time:
+                if not oldest_secondary_optime or optime.time < oldest_secondary_optime:
                     oldest_secondary_optime = optime.time
 
         if not primary_optime or not oldest_secondary_optime:


### PR DESCRIPTION
oldest_secondary_optime is an int value, not a  time.time value
after change it will be workable
